### PR TITLE
Clean up tests and docs for batch execution

### DIFF
--- a/doc/topics/netapi/index.rst
+++ b/doc/topics/netapi/index.rst
@@ -42,5 +42,5 @@ simply by creating a data structure. (And this is exactly how much of Salt's
 own internals work!)
 
 .. autoclass:: salt.netapi.NetapiClient
-    :members: local, local_async, local_batch, ssh, ssh_async, runner,
+    :members: local, local_async, ssh, ssh_async, runner,
         runner_async, wheel, wheel_async

--- a/salt/netapi/rest_tornado/saltnado.py
+++ b/salt/netapi/rest_tornado/saltnado.py
@@ -692,7 +692,7 @@ class SaltAPIHandler(BaseSaltAPIHandler, SaltClientsMixIn):  # pylint: disable=W
             Content-Type: application/json
             Content-Legnth: 83
 
-            {"clients": ["local", "local_batch", "local_async", "runner", "runner_async"], "return": "Welcome"}
+            {"clients": ["local", "local_async", "runner", "runner_async"], "return": "Welcome"}
         '''
         ret = {"clients": list(self.saltclients.keys()),
                "return": "Welcome"}

--- a/tests/integration/netapi/rest_tornado/test_app.py
+++ b/tests/integration/netapi/rest_tornado/test_app.py
@@ -48,13 +48,12 @@ class TestSaltAPIHandler(SaltnadoTestCase):
                 )
         self.assertEqual(response.code, 200)
         response_obj = json.loads(response.body)
-        self.assertEqual(response_obj['clients'],
-                         ['runner',
-                          'runner_async',
-                          'local_async',
-                          'local',
-                          'local_batch']
-                         )
+        self.assertItemsEqual(response_obj['clients'],
+                              ['runner',
+                               'runner_async',
+                               'local_async',
+                               'local']
+                              )
         self.assertEqual(response_obj['return'], 'Welcome')
 
     def test_post_no_auth(self):
@@ -116,68 +115,6 @@ class TestSaltAPIHandler(SaltnadoTestCase):
                               )
         response_obj = json.loads(response.body)
         self.assertEqual(response_obj['return'], ["No minions matched the target. No command was sent, no jid was assigned."])
-
-    # local_batch tests
-    @skipIf(True, 'to be reenabled when #23623 is merged')
-    def test_simple_local_batch_post(self):
-        '''
-        Basic post against local_batch
-        '''
-        low = [{'client': 'local_batch',
-                'tgt': '*',
-                'fun': 'test.ping',
-                }]
-        response = self.fetch('/',
-                              method='POST',
-                              body=json.dumps(low),
-                              headers={'Content-Type': self.content_type_map['json'],
-                                       saltnado.AUTH_TOKEN_HEADER: self.token['token']},
-                              connect_timeout=30,
-                              request_timeout=30,
-                              )
-        response_obj = json.loads(response.body)
-        self.assertEqual(response_obj['return'], [{'minion': True, 'sub_minion': True}])
-
-    # local_batch tests
-    @skipIf(True, 'to be reenabled when #23623 is merged')
-    def test_full_local_batch_post(self):
-        '''
-        Test full parallelism of local_batch
-        '''
-        low = [{'client': 'local_batch',
-                'tgt': '*',
-                'fun': 'test.ping',
-                'batch': '100%',
-                }]
-        response = self.fetch('/',
-                              method='POST',
-                              body=json.dumps(low),
-                              headers={'Content-Type': self.content_type_map['json'],
-                                       saltnado.AUTH_TOKEN_HEADER: self.token['token']},
-                              connect_timeout=30,
-                              request_timeout=30,
-                              )
-        response_obj = json.loads(response.body)
-        self.assertEqual(response_obj['return'], [{'minion': True, 'sub_minion': True}])
-
-    def test_simple_local_batch_post_no_tgt(self):
-        '''
-        Local_batch testing with no tgt
-        '''
-        low = [{'client': 'local_batch',
-                'tgt': 'minion_we_dont_have',
-                'fun': 'test.ping',
-                }]
-        response = self.fetch('/',
-                              method='POST',
-                              body=json.dumps(low),
-                              headers={'Content-Type': self.content_type_map['json'],
-                                       saltnado.AUTH_TOKEN_HEADER: self.token['token']},
-                              connect_timeout=30,
-                              request_timeout=30,
-                              )
-        response_obj = json.loads(response.body)
-        self.assertEqual(response_obj['return'], [{}])
 
     # local_async tests
     def test_simple_local_async_post(self):
@@ -400,7 +337,7 @@ class TestMinionSaltAPIHandler(SaltnadoTestCase):
         make sure you get an error
         '''
         # get a token for this test
-        low = [{'client': 'local_batch',
+        low = [{'client': 'local',
                 'tgt': '*',
                 'fun': 'test.ping',
                 }]


### PR DESCRIPTION
Batch execution was removed from NetapiClient and Saltnado in
previous commits. This change is a follow up that removes related
test cases and doc references.

Refs #19
